### PR TITLE
Fix initial oauth connection

### DIFF
--- a/src/GmailConnection.php
+++ b/src/GmailConnection.php
@@ -3,6 +3,7 @@
 namespace Amchara\LaravelGmail;
 
 use Amchara\LaravelGmail\Traits\Configurable;
+use App\MailConfig;
 use Google_Client;
 use Google_Service_Gmail;
 use Illuminate\Container\Container;
@@ -146,6 +147,12 @@ class GmailConnection extends Google_Client
 
         $credentials = $this->getClientGmailCredentials();
 
+        if (!$credentials){
+            $credentials = new MailConfig();
+            $credentials->practitioner_id = auth()->user()->id;
+            $credentials->type = 'google';
+            $credentials->status = 'active';
+        }
         $allowJsonEncrypt = $this->_config['gmail.allow_json_encrypt'];
 
         $config['email'] = $this->emailAddress;


### PR DESCRIPTION
Create MailConfig for users on first access.

Problem:
When setting up the gmail integrations I get a server error: Creating default object from empty value.
So our laravel-gmail library has a saveAccessToken() function in GmailConnection.php. Here we try to get client gmail credentials and update them.
However, it calls a function getClientGmailCredentials(). Here, we are looking for a MailConfig (mail_configs) record by practitioner_id. However it is not found, so returns null. Then we try to treat the returned value as an array, hence the "creating default object" error.

The problem is, I can't see anywhere in the codebase where we create MailConfig items. So I'm guessing we've missed this part on the rebuild? I've searched the codebase and can't find any example of them being created and persisted to the db. So every time, we will look for them, it will not find and will error when we call save() on the null value returned from getClientGmailCredentials()